### PR TITLE
docs(getting started): add import on getting started section

### DIFF
--- a/pages/features/abortion.mdx
+++ b/pages/features/abortion.mdx
@@ -14,10 +14,11 @@ You can set an timeout delay for all resources in your core provider.
 
 ```tsx
 function MyWrapper() {
-  return <XSWR.CoreProvider
-    timeout={5000}>
-    <MyAwesomeApp />
-  </XSWR.CoreProvider>
+  return (
+    <CoreProvider timeout={5000}>
+      <MyAwesomeApp />
+    </CoreProvider>
+  )
 }
 ```
 
@@ -72,9 +73,11 @@ You can use `query.aborter.abort` to abort the ongoing request, or `query.aborte
 const mydata = useMyData()
 const { aborter } = mydata
 
-return <button onClick={aborter.abort}>
-  Abort
-<button />
+return (
+  <button onClick={aborter.abort}>
+    Abort
+  <button />
+)
 ```
 
 Note: `query.aborter` is `undefined` is there is no ongoing request.

--- a/pages/features/cooldown.mdx
+++ b/pages/features/cooldown.mdx
@@ -16,10 +16,11 @@ You can set a cooldown delay for all resources in your core provider.
 
 ```tsx
 function MyWrapper() {
-  return <XSWR.CoreProvider
-    cooldown={5000}>
-    <MyAwesomeApp />
-  </XSWR.CoreProvider>
+  return (
+    <CoreProvider cooldown={5000}>
+      <MyAwesomeApp />
+    </CoreProvider>
+  )
 }
 ```
 

--- a/pages/features/garbage.mdx
+++ b/pages/features/garbage.mdx
@@ -14,10 +14,11 @@ You can set an expiration delay for all resources in your core provider.
 
 ```tsx
 function MyWrapper() {
-  return <XSWR.CoreProvider
-    expiration={60 * 1000}>
-    <MyAwesomeApp />
-  </XSWR.CoreProvider>
+  return (
+    <CoreProvider expiration={60 * 1000}>
+      <MyAwesomeApp />
+    </CoreProvider>
+  )
 }
 ```
 

--- a/pages/features/storage.mdx
+++ b/pages/features/storage.mdx
@@ -45,10 +45,11 @@ You can also pass it into a CoreProvider to enable persistent storage for all ch
 const storage = new IDBStorage("mydb")
 
 function MyWrapper() {
-  return <XSWR.CoreProvider
-    storage={storage}>
-    <MyApp />
-  </XSWR.CoreProvider>
+  return (
+    <CoreProvider storage={storage}>
+      <MyApp />
+    </CoreProvider>
+  )
 }
 ```
 

--- a/pages/getting-started/advanced.mdx
+++ b/pages/getting-started/advanced.mdx
@@ -29,6 +29,8 @@ It also returns an error if the request failed.
 Using schemas may seems boilerplate, but it will save you a lot of time later.
 
 ```tsx
+import { getSingleSchema } from '@hazae41/xswr';
+
 function getHelloSchema() {
   return getSingleSchema<Hello>("/api/hello", fetchAsJson)
 }
@@ -41,6 +43,8 @@ It allows you to reuse the same set of key+fetcher+params in multiple places, in
 The mixtures pattern allows you to reuse the same group of blocks.
 
 ```tsx
+import { useFetch, useVisible, useOnline } from '@hazae41/xswr';
+
 function useAutoFetchMixture(query: Query) {
   useFetch(query)
   useVisible(query)
@@ -53,6 +57,8 @@ function useAutoFetchMixture(query: Query) {
 Once you got a schema and a mixture, you just have to mix it.
 
 ```tsx
+import { useQuery, useAutoFetchMixture } from '@hazae41/xswr';
+
 function useHelloMix() {
   const query = useQuery(getHelloSchema, [])
   useAutoFetchMixture(query)

--- a/pages/getting-started/installation.mdx
+++ b/pages/getting-started/installation.mdx
@@ -13,9 +13,9 @@ import { CoreProvider } from '@hazae41/xswr';
 
 function MyWrapper() {
   return (
-    <XSWR.CoreProvider>
+    <CoreProvider>
       <MyAwesomeApp />
-    </XSWR.CoreProvider>
+    </CoreProvider>
   )
 }
 ```

--- a/pages/getting-started/installation.mdx
+++ b/pages/getting-started/installation.mdx
@@ -9,9 +9,13 @@ npm i @hazae41/xswr
 Then, wrap your app in a `XSWR.CoreProvider` component.
 
 ```tsx
+import { CoreProvider } from '@hazae41/xswr';
+
 function MyWrapper() {
-  return <XSWR.CoreProvider>
-    <MyAwesomeApp />
-  </XSWR.CoreProvider>
+  return (
+    <XSWR.CoreProvider>
+      <MyAwesomeApp />
+    </XSWR.CoreProvider>
+  )
 }
 ```

--- a/pages/getting-started/your-first-mix.mdx
+++ b/pages/getting-started/your-first-mix.mdx
@@ -21,6 +21,8 @@ async function fetchAsJson<T>(url: string) {
 Then create a mix using a query and some blocks.
 
 ```tsx
+import { useSingleQuery } from '@hazae41/xswr';
+
 function useHello() {
   const query = useSingleQuery<Hello>(`/api/hello`, fetchAsJson)
   


### PR DESCRIPTION
Hey, i add the import section in the getting started to be clear.

I add the `()` in the provider demo and remove namespace import